### PR TITLE
perform calculation regardless of radius change

### DIFF
--- a/paper-clock-selector.html
+++ b/paper-clock-selector.html
@@ -366,9 +366,12 @@
         },
         _updateSize: function() {
           var radius = Math.min(this.offsetWidth, this.offsetHeight) / 2;
-          if (!radius || this._resizedCache === radius) {
-            return;
-          }
+          //Since we use the paper-time-picker in a resizable window, we still want to perform
+          //the calculations below regardless of whether or not the radius of the circle has changed
+          //These calculations are important for the actual process of selection via a clock hand
+          // if (!radius || this._resizedCache === radius) {
+          //   return;
+          // }
           
           this.set("numberOffsetX", (radius));
           this.set("numberOffsetY", (radius*1.013));

--- a/paper-clock-selector.html
+++ b/paper-clock-selector.html
@@ -369,9 +369,9 @@
           //Since we use the paper-time-picker in a resizable window, we still want to perform
           //the calculations below regardless of whether or not the radius of the circle has changed
           //These calculations are important for the actual process of selection via a clock hand
-          // if (!radius || this._resizedCache === radius) {
-          //   return;
-          // }
+          if (!radius) {
+             return;
+          }
           
           this.set("numberOffsetX", (radius));
           this.set("numberOffsetY", (radius*1.013));


### PR DESCRIPTION
Since our time picker is in a resizable window, the position of the clock will change without the radius changing in most cases, therefore, the return statement breaks the clock hand's functionality when the window is moved.
https://github.com/zawarski/palmetto-app-battlerhythms/issues/2